### PR TITLE
FTP passive mode enhancement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,11 +78,14 @@ Alarm Server will accept any username as FTP login username and use it as camera
 
 ```yaml
 ftp:
-  enabled: true      # if not enabled, it won't accept connections
-  port: 21           # has to match settings in the cameras
-  password: "root"   # FTP password that will be accepted
-  allowFiles: true   # if false, no files will be stored (but transfers will still happen)
-  rootPath: "./ftp"  # folder where to save cameras' uploads
+  enabled: true               # if not enabled, it won't accept connections
+  port: 21                    # has to match settings in the cameras
+  password: "root"            # FTP password that will be accepted
+  allowFiles: true            # if false, no files will be stored (but transfers will still happen)
+  rootPath: "./ftp"           # folder where to save cameras' uploads
+  publicIp: "192.168.0.2"     # Optional - specify FTP server real public IP
+  passivePorts: "21000-21010" # Optional - specify passive mode port range
+
 ```
 
 _Q_: Isn't FTP, like, slow??
@@ -111,7 +114,7 @@ If your camera works with Alarm Server - create an issue with some details about
 
 There is a pre-built image `toxuin/alarmserver`. It is a multi-architecture image and will work both on Intel/AMD machines, and your Raspberry PI too.
 
-Usage: `docker run -d -v $PWD/config.yml:/config.yml -v $PWD/ftp:/ftp -p 21:21 -p 15002:15002 toxuin/alarmserver`
+Usage: `docker run -d -v $PWD/config.yaml:/config.yaml -v $PWD/ftp:/ftp -p 21:21 -p 15002:15002 -p 21000-21010 toxuin/alarmserver`
 
 Explanation:
 
@@ -124,6 +127,9 @@ Explanation:
   - `-p 21:21` allows your machine to pass through port 21 that is used for FTP server. Not needed if you're not using FTP server.
 
   - `-p 15002:15002` same as above, but for port 15002 that's used by HiSilicon alarms server. Not needed if you don't need HiSilicon server.
+
+  - `-p 21000-21010` Optional. Allow pass through FTP passive mode ports specified in the config.
+
 
 ## Feedback
 

--- a/config/config.go
+++ b/config/config.go
@@ -56,11 +56,13 @@ type DahuaConfig struct {
 }
 
 type FtpConfig struct {
-	Enabled    bool   `json:"enabled"`
-	Port       int    `json:"port"`
-	AllowFiles bool   `json:"allowFiles"`
-	Password   string `json:"password"`
-	RootPath   string `json:"rootPath"`
+	Enabled      bool   `json:"enabled"`
+	Port         int    `json:"port"`
+	AllowFiles   bool   `json:"allowFiles"`
+	Password     string `json:"password"`
+	RootPath     string `json:"rootPath"`
+	PublicIP     string `json:"publicIP"`
+	PassivePorts string `json:"passivePorts"` // Port range notation. Example: "21000-21010"
 }
 
 func (c *Config) SetDefaults() {
@@ -279,6 +281,8 @@ func (c *Config) Printout() {
 		"    files allowed: %t\n"+
 		"    password set: %t\n"+
 		"    root path: %s\n"+
+		"    public IP: %s\n"+
+		"    passive ports: %s\n"+
 		"  BUS: MQTT - enabled: %t\n"+
 		"    port: %s\n"+
 		"    topicRoot: %s\n"+
@@ -298,6 +302,8 @@ func (c *Config) Printout() {
 		c.Ftp.AllowFiles,
 		c.Ftp.Password != "",
 		c.Ftp.RootPath,
+		c.Ftp.PublicIP,
+		c.Ftp.PassivePorts,
 		c.Mqtt.Enabled,
 		c.Mqtt.Port,
 		c.Mqtt.TopicRoot,

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -40,6 +40,11 @@ ftp:
   password: "root"
   allowFiles: true
   rootPath: "./ftp"
+  # THE FOLLOWING SETTINGS ARE OPTIONAL. Mainly intended for proper connectivity when running in Docker container
+  publicIp: "192.168.0.2"
+  # Export these ports in the container config "-p 21000-21010:21000-21010"
+  passivePorts: "21000-21010"
+
 
 mqtt:
   enabled: true

--- a/main.go
+++ b/main.go
@@ -107,6 +107,8 @@ func main() {
 			AllowFiles:     config.Ftp.AllowFiles,
 			RootPath:       config.Ftp.RootPath,
 			Password:       config.Ftp.Password,
+			PublicIP:       config.Ftp.PublicIP,
+			PassivePorts:   config.Ftp.PassivePorts,
 			MessageHandler: messageHandler,
 		}
 		ftpServer.Start()

--- a/servers/ftp/server.go
+++ b/servers/ftp/server.go
@@ -7,12 +7,15 @@ import (
 )
 
 type Server struct {
-	Debug          bool
-	WaitGroup      *sync.WaitGroup
-	Port           int
-	AllowFiles     bool
-	RootPath       string
-	Password       string
+	Debug        bool
+	WaitGroup    *sync.WaitGroup
+	Port         int
+	AllowFiles   bool
+	RootPath     string
+	Password     string
+	PublicIP     string
+	PassivePorts string
+
 	MessageHandler func(cameraName string, eventType string, extra string)
 }
 
@@ -60,6 +63,8 @@ func (serv *Server) Start() {
 			Port:           serv.Port,
 			Perm:           server.NewSimplePerm("root", "root"),
 			Auth:           &DumbAuth{Debug: serv.Debug, Password: serv.Password},
+			PublicIP:       serv.PublicIP,
+			PassivePorts:   serv.PassivePorts,
 		}
 
 		if !serv.Debug {


### PR DESCRIPTION
Allow specifying public IP and port range for FTP passive mode.

Added two configuration values for FTP server:

- `publicIp` - override the docker internal IP with the host IP address
- `passivePorts` - specify the port range for the passive mode. These ports need to be passed through to the host in the container run config.