### PR TITLE
#47: Allow custom event-time-format for hikvision

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/spf13/viper"
 	"github.com/toxuin/alarmserver/servers/dahua"
 	"github.com/toxuin/alarmserver/servers/hikvision"
-	"strings"
 )
 
 type Config struct {
@@ -181,11 +182,17 @@ func (c *Config) Load() *Config {
 				}
 				url += camConfig.GetString("address") + "/ISAPI/"
 
+				timeFormat := hikvision.DefaultEventTimeFormat
+				if timeFormatOverride := camConfig.GetString("event-time-format"); timeFormatOverride != "" {
+					timeFormat = timeFormatOverride
+				}
+
 				camera := hikvision.HikCamera{
-					Name:     camName,
-					Url:      url,
-					Username: camConfig.GetString("username"),
-					Password: camConfig.GetString("password"),
+					Name:            camName,
+					Url:             url,
+					Username:        camConfig.GetString("username"),
+					Password:        camConfig.GetString("password"),
+					EventTimeFormat: timeFormat,
 				}
 				if camConfig.GetBool("rawTcp") {
 					camera.BrokenHttp = true

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/subosito/gotenv v1.4.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e h1:TsQ7F31D3bUCLeqPT0u+yjp1g
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -499,6 +501,8 @@ golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -511,6 +515,8 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/servers/hikvision/httpEventReader.go
+++ b/servers/hikvision/httpEventReader.go
@@ -3,13 +3,14 @@ package hikvision
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/icholy/digest"
 	"io"
 	"log"
 	"mime"
 	"mime/multipart"
 	"net/http"
 	"strconv"
+
+	"github.com/icholy/digest"
 )
 
 type HttpEventReader struct {
@@ -61,7 +62,11 @@ func (eventReader *HttpEventReader) ReadEvents(camera *HikCamera, channel chan<-
 	}
 	multipartBoundary := params["boundary"]
 
-	xmlEvent := XmlEvent{}
+	xmlEvent := XmlEvent{
+		Time: xmlEventTime{
+			customFormat: camera.EventTimeFormat,
+		},
+	}
 
 	// READ PART BY PART
 	multipartReader := multipart.NewReader(response.Body, multipartBoundary)
@@ -92,7 +97,7 @@ func (eventReader *HttpEventReader) ReadEvents(camera *HikCamera, channel chan<-
 		xmlEvent.Camera = camera
 
 		if eventReader.Debug {
-			log.Printf("%s event: %s (%s - %d)", xmlEvent.Camera.Name, xmlEvent.Type, xmlEvent.State, xmlEvent.Id)
+			log.Printf("[%s] %s event: %s (%s - %d) - %s", xmlEvent.Time.Format("2006-01-02T15:04:05"), xmlEvent.Camera.Name, xmlEvent.Type, xmlEvent.State, xmlEvent.Id, xmlEvent.Description)
 		}
 
 		switch xmlEvent.State {

--- a/servers/hikvision/tcpEventReader.go
+++ b/servers/hikvision/tcpEventReader.go
@@ -120,7 +120,12 @@ func (eventReader *TcpEventReader) ReadEvents(camera *HikCamera, channel chan<- 
 
 		// READ ACTUAL EVENTS
 		var eventString string
-		xmlEvent := XmlEvent{}
+		xmlEvent := XmlEvent{
+			Time: xmlEventTime{
+				customFormat: camera.EventTimeFormat,
+			},
+		}
+
 		for {
 			line, err := textConn.ReadLine()
 			if err == io.EOF { // CONNECTION CLOSED


### PR DESCRIPTION
Fixes #47

Allow custom event time formats for hikvision, I cannot identify why my DVR does not want to return a timezone with the event time, could be because my timezone is UTC? However to support it, I have added the default and ability to support custom formats via the config.

This seemed like a specific camera option and not global, since it can change from one ISAPI implementation to another.

---

DVR: Annke N48PBB https://www.annke.com/products/6mp-8ch-poe-nvr